### PR TITLE
[3/3] sepolicy: add support for adb over network

### DIFF
--- a/private/system_server.te
+++ b/private/system_server.te
@@ -519,6 +519,7 @@ set_prop(system_server, exported_pm_prop)
 set_prop(system_server, theme_prop)
 set_prop(system_server, exported_theme_prop)
 userdebug_or_eng(`set_prop(system_server, wifi_log_prop)')
+set_prop(system_server, shell_prop)
 
 # ctl interface
 set_prop(system_server, ctl_default_prop)


### PR DESCRIPTION
Prevents crash when enabling adb over network on enforcing builds.

Change-Id: Ife265c90aa5e40718286517b1540afe80e1dfb5c