### PR TITLE
Fix bootloop issue of SD card

### DIFF
--- a/private/domain.te
+++ b/private/domain.te
@@ -271,6 +271,7 @@ define(`dac_override_allowed', `{
   vold
   vold_prepare_subdirs
   zygote
+  fsck
 }')
 neverallow ~dac_override_allowed self:global_capability_class_set dac_override;
 # Since the kernel checks dac_read_search before dac_override, domains that


### PR DESCRIPTION
Bootloop on inserting/pre-inserted SD card have been reported by users. Not all SD cards face this issue of bootlooping. Users had to format SD card to get it working.

Upon seeing the logs, found the long repetitive denials of `fsck` of `dac_override` and `dac_read_search` permissions. This commit should fix it.

More description in commit message.